### PR TITLE
Add options to specify fallback languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,13 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+### Deprecated
  * Deprecate Node.JS 4 and require Node.JS >= 6
+### Added
  * Note about adding a stylesheet to the HTML in README
+ * Options `defaultLanguage`, `defaultLanguageForUnknown` and `defaultLanguageForUnspecified` to specify fallback prism languages
+### Fixed
+ * Update all packages and eliminate dependency versions with known security issues
 
 ## [1.1.2] – 2018-03-17
  * Upgrade dependencies

--- a/README.md
+++ b/README.md
@@ -18,3 +18,6 @@ Name   | Description | Default
 -------|-------------|--------
 `plugins` | Array of [Prism Plugins](http://prismjs.com/#plugins) to load. The names to use can be found [here](https://github.com/PrismJS/prism/tree/master/plugins). Please note that some prism plugins (notably line-numbers) rely on the DOM being present and can thus not be used with this package (see [#1](https://github.com/jGleitz/markdown-it-prism/issues/1)). | `[]`
 `init` | A function called after setting up prism. Will receive the prism instance as only argument. Useful for plugins needing further intialisation. | `() => {}`
+`defaultLanguageForUnknown` | The language to use for code blocks that specify a language that Prism does not know. No default will be used if this option is `undefined`. | `undefined`
+`defaultLanguageForUnspecified` | The language to use for code block that do not specify a language. No default will be used if this option is `undefined`. | `undefined`
+`defaultLanguage` | Shorthand to set both `defaultLanguageForUnknown` and `defaultLanguageForUnspecified` to the same value. | `undefined`

--- a/index.js
+++ b/index.js
@@ -2,7 +2,10 @@ import Prism from 'prismjs';
 
 const DEFAULTS = {
 	plugins: [],
-	init: () => {}
+	init: () => {},
+	defaultLanguage: undefined,
+	defaultLanguageForUnknown: undefined,
+	defaultLanguageForUnspecified: undefined
 };
 
 
@@ -14,6 +17,7 @@ const DEFAULTS = {
  * @return <Object?> The Prism language object for the provided <code>lang</code> code. <code>undefined</code> if the code is not known to Prism.
  */
 function loadPrismLang(lang) {
+	if (!lang) return null;
 	let langObject = Prism.languages[lang];
 	if (langObject === undefined) {
 		try {
@@ -34,32 +38,71 @@ function loadPrismPlugin(name) {
 	}
 }
 
+
+/**
+ * Select the language to use for highlighting, based on the provided options and the specified language.
+ *
+ * @param <Object> options
+ * 		The options that were used to initialise the plugin.
+ * @param <String> lang
+ *		Code of the language to highlight the text in.
+ * @return <Array> An array where the first element is the name of the language to use, and the second element is the PRISM language object for that language.
+ */
+function selectLanguage(options, lang) {
+	let langToUse = lang;
+	if (langToUse == '' && options.defaultLanguageForUnspecified !== undefined) {
+		langToUse = options.defaultLanguageForUnspecified;
+	}
+	let prismLang = loadPrismLang(langToUse);
+	if (prismLang === undefined && options.defaultLanguageForUnknown !== undefined) {
+		langToUse = options.defaultLanguageForUnknown;
+		prismLang = loadPrismLang(langToUse);
+	}
+	return [langToUse, prismLang];
+}
+
 /**
  * Highlights the provided text using Prism.
  *
  * @param <MarkdownIt> markdownit
  * 		Instance of MarkdownIt Class. This argument is bound in markdownItPrism().
+ * @param <Object> options
+ *		The options that have been used to initialise the plugin. This argument is bound in markdownItPrism().
  * @param <String> text
  * 		The text to highlight.
  * @param <String> lang
  *		Code of the language to highlight the text in.
  * @return <String> <code>text</code> wrapped in <code>&lt;pre&gt;</code> and <code>&lt;code&gt;</code>, both equipped with the appropriate class (markdown-it’s langPrefix + lang). If Prism knows <code>lang</code>, <code>text</code> will be highlighted by it.
  */
-function highlight(markdownit, text, lang) {
-	const prismLang = loadPrismLang(lang);
+function highlight(markdownit, options, text, lang) {
+	let langToUse, prismLang;
+	[langToUse, prismLang] = selectLanguage(options, lang);
 	const code = prismLang ? Prism.highlight(text, prismLang) : markdownit.utils.escapeHtml(text);
-	const classAttribute = lang ? ` class="${markdownit.options.langPrefix}${lang}"` : '';
+	const classAttribute = langToUse ? ` class="${markdownit.options.langPrefix}${langToUse}"` : '';
 	return `<pre${classAttribute}><code${classAttribute}>${code}</code></pre>`;
+}
+
+function checkLanguage(options, optionName) {
+	const language = options[optionName];
+	if (language !== undefined && loadPrismLang(language) === undefined) {
+		throw new Error(`Bad option ${optionName}: There is no Prism language '${language}'.`);
+	}
 }
 
 function markdownItPrism(markdownit, useroptions) {
 	const options = Object.assign({}, DEFAULTS, useroptions);
 
+	checkLanguage(options, 'defaultLanguage');
+	checkLanguage(options, 'defaultLanguageForUnknown');
+	checkLanguage(options, 'defaultLanguageForUnspecified');
+	options.defaultLanguageForUnknown = options.defaultLanguageForUnknown || options.defaultLanguage;
+	options.defaultLanguageForUnspecified = options.defaultLanguageForUnspecified || options.defaultLanguage;
+
 	options.plugins.forEach(loadPrismPlugin);
 	options.init(Prism);
 
 	// register ourselves as highlighter
-	markdownit.options.highlight = (...args) => highlight(markdownit, ...args);
+	markdownit.options.highlight = (...args) => highlight(markdownit, options, ...args);
 }
 
 export default markdownItPrism;

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const DEFAULTS = {
  * @return <Object?> The Prism language object for the provided <code>lang</code> code. <code>undefined</code> if the code is not known to Prism.
  */
 function loadPrismLang(lang) {
-	if (!lang) return null;
+	if (!lang) return undefined;
 	let langObject = Prism.languages[lang];
 	if (langObject === undefined) {
 		try {

--- a/test.js
+++ b/test.js
@@ -26,6 +26,27 @@ describe('markdown-it-prism', () => {
 			})).to.throw(Error, /plugin/);
 	});
 
+	it('throws for unknown defaultLanguage', () => {
+		expect(() => markdownit()
+			.use(markdownItPrism, {
+				defaultLanguage: 'i-dont-exist'
+			})).to.throw(Error, /defaultLanguage.*i-dont-exist/);
+	});
+
+	it('throws for unknown defaultLanguageForUnknown', () => {
+		expect(() => markdownit()
+			.use(markdownItPrism, {
+				defaultLanguageForUnknown: 'i-dont-exist'
+			})).to.throw(Error, /defaultLanguageForUnknown.*i-dont-exist/);
+	});
+
+	it('throws for unknown defaultLanguageForUnspecified', () => {
+		expect(() => markdownit()
+			.use(markdownItPrism, {
+				defaultLanguageForUnspecified: 'i-dont-exist'
+			})).to.throw(Error, /defaultLanguageForUnspecified.*i-dont-exist/);
+	});
+
 	it('offers an init function for further initialisation', () => {
 		let called = false;
 		markdownit()
@@ -45,6 +66,24 @@ describe('markdown-it-prism', () => {
 		).to.equalIgnoreSpaces(read('expected/fenced-without-language.html'));
 	});
 
+	it('falls back to defaultLanguageForUnspecified if no language is specified', () => {
+		expect(markdownit()
+			.use(markdownItPrism, {
+				defaultLanguageForUnspecified: 'java'
+			})
+			.render(read('input/fenced-without-language.md'))
+		).to.equalIgnoreSpaces(read('expected/fenced-with-language.html'));
+	});
+
+	it('falls back to defaultLanguage if no language and no defaultLanguageForUnspecified is specified', () => {
+		expect(markdownit()
+			.use(markdownItPrism, {
+				defaultLanguage: 'java'
+			})
+			.render(read('input/fenced-without-language.md'))
+		).to.equalIgnoreSpaces(read('expected/fenced-with-language.html'));
+	});
+
 	it('does not add classes to indented code blocks', () => {
 		expect(markdownit()
 			.use(markdownItPrism)
@@ -58,6 +97,24 @@ describe('markdown-it-prism', () => {
 			.use(markdownItPrism)
 			.render(read('input/fenced-with-unknown-language.md'))
 		).to.equalIgnoreSpaces(read('expected/fenced-with-unknown-language.html'));
+	});
+
+	it('falls back to defaultLanguageForUnknown if the specified language is unknown', () => {
+		expect(markdownit()
+			.use(markdownItPrism, {
+				defaultLanguageForUnknown: 'java'
+			})
+			.render(read('input/fenced-with-unknown-language.md'))
+		).to.equalIgnoreSpaces(read('expected/fenced-with-language.html'));
+	});
+
+	it('falls back to defaultLanguage if the specified language is unknown and no defaultLanguageForUnknown is specified', () => {
+		expect(markdownit()
+			.use(markdownItPrism, {
+				defaultLanguage: 'java'
+			})
+			.render(read('input/fenced-with-unknown-language.md'))
+		).to.equalIgnoreSpaces(read('expected/fenced-with-language.html'));
 	});
 
 	it('respects markdown-it’s langPrefix setting', () => {

--- a/testdata/expected/fenced-with-language-plugins.html
+++ b/testdata/expected/fenced-with-language-plugins.html
@@ -1,6 +1,6 @@
 <h1>Test</h1>
 
-<p>This is a fenced code block with language specification:</p>
+<p>This is a fenced code block:</p>
 <pre class="language-java"><code class="language-java">
 	<span class="token keyword keyword-public">public</span> <span class="token keyword keyword-class">class</span> <span class="token class-name">Foo</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
 		<span class="token keyword keyword-public">public</span> <span class="token function">Foo</span><span class="token punctuation">(</span>bar<span class="token punctuation">)</span> <span class="token punctuation">{</span>

--- a/testdata/expected/fenced-with-language-prefix.html
+++ b/testdata/expected/fenced-with-language-prefix.html
@@ -1,6 +1,6 @@
 <h1>Test</h1>
 
-<p>This is a fenced code block with language specification:</p>
+<p>This is a fenced code block:</p>
 <pre class="test-java"><code class="test-java">
 	<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token class-name">Foo</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
 		<span class="token keyword">public</span> <span class="token function">Foo</span><span class="token punctuation">(</span>bar<span class="token punctuation">)</span> <span class="token punctuation">{</span>

--- a/testdata/expected/fenced-with-language.html
+++ b/testdata/expected/fenced-with-language.html
@@ -1,6 +1,6 @@
 <h1>Test</h1>
 
-<p>This is a fenced code block with language specification:</p>
+<p>This is a fenced code block:</p>
 <pre class="language-java"><code class="language-java">
 	<span class="token keyword">public</span> <span class="token keyword">class</span> <span class="token class-name">Foo</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
 		<span class="token keyword">public</span> <span class="token function">Foo</span><span class="token punctuation">(</span>bar<span class="token punctuation">)</span> <span class="token punctuation">{</span>

--- a/testdata/expected/fenced-with-unknown-language.html
+++ b/testdata/expected/fenced-with-unknown-language.html
@@ -1,6 +1,6 @@
 <h1>Test</h1>
 
-<p>This is a fenced code block with language specification of an unknown language:</p>
+<p>This is a fenced code block:</p>
 <pre class="language-this-is-not-a-language"><code class="language-this-is-not-a-language">
 	public class Foo() {
 		public Foo(bar) {

--- a/testdata/expected/fenced-without-language.html
+++ b/testdata/expected/fenced-without-language.html
@@ -1,6 +1,6 @@
 <h1>Test</h1>
 
-<p>This is a fenced code block without language specification:</p>
+<p>This is a fenced code block:</p>
 <pre><code>
 	public class Foo() {
 		public Foo(bar) {

--- a/testdata/input/fenced-with-language.md
+++ b/testdata/input/fenced-with-language.md
@@ -1,6 +1,6 @@
 # Test
 
-This is a fenced code block with language specification:
+This is a fenced code block:
 
 ```java
 public class Foo() {

--- a/testdata/input/fenced-with-unknown-language.md
+++ b/testdata/input/fenced-with-unknown-language.md
@@ -1,6 +1,6 @@
 # Test
 
-This is a fenced code block with language specification of an unknown language:
+This is a fenced code block:
 
 ```this-is-not-a-language
 public class Foo() {

--- a/testdata/input/fenced-without-language.md
+++ b/testdata/input/fenced-without-language.md
@@ -1,6 +1,6 @@
 # Test
 
-This is a fenced code block without language specification:
+This is a fenced code block:
 
 ```
 public class Foo() {


### PR DESCRIPTION
Adds the following options and implements and tests them:

 Name   | Description | Default
-------|-------------|--------
`defaultLanguageForUnknown` | The language to use for code blocks that specify a language that Prism does not know. No default will be used if this option is `undefined`. | `undefined`
`defaultLanguageForUnspecified` | The language to use for code block that do not specify a language. No default will be used if this option is `undefined`. | `undefined`
`defaultLanguage` | Shorthand to set both `defaultLanguageForUnknown` and `defaultLanguageForUnspecified` to the same value. | `undefined`

fixes #12