### PR TITLE
fix: XSS vulnerability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ function selectLanguage(options: Options, lang: string): [string, Grammar | unde
 function highlight(markdownit: MarkdownIt, options: Options, text: string, lang: string): string {
 	const [langToUse, prismLang] = selectLanguage(options, lang)
 	const code = prismLang ? Prism.highlight(text, prismLang, langToUse) : markdownit.utils.escapeHtml(text)
-	const classAttribute = langToUse ? ` class="${markdownit.options.langPrefix}${langToUse}"` : ''
+	const classAttribute = langToUse ? ` class="${markdownit.options.langPrefix}${markdownit.utils.escapeHtml(langToUse)}"` : ''
 	return `<pre${classAttribute}><code${classAttribute}>${code}</code></pre>`
 }
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -80,7 +80,6 @@ describe('markdown-it-prism', () => {
 			.use(markdownItPrism)
 			.render(await read('input/indented.md'))
 		).toEqual(await read('expected/indented.html'))
-
 	})
 
 	it('adds classes even if the language is unknown', async () => {
@@ -88,6 +87,13 @@ describe('markdown-it-prism', () => {
 			.use(markdownItPrism)
 			.render(await read('input/fenced-with-unknown-language.md'))
 		).toEqual(await read('expected/fenced-with-unknown-language.html'))
+	})
+
+	it('escapes HTML in the language name', async () => {
+		expect(markdownit()
+			.use(markdownItPrism)
+			.render(await read('input/fenced-with-html-in-language.md'))
+		).toEqual(await read('expected/fenced-with-html-in-language.html'))
 	})
 
 	it('falls back to defaultLanguageForUnknown if the specified language is unknown', async () => {

--- a/testdata/expected/fenced-with-html-in-language.html
+++ b/testdata/expected/fenced-with-html-in-language.html
@@ -1,6 +1,6 @@
 <h1>Test</h1>
 <p>This is a fenced code block:</p>
-<pre class="language-&lt;img/onerror=&quot;alert('hacked')&quot;src=.&gt;"><code class="language-&lt;img/onerror=&quot;alert('hacked')&quot;src=.&gt;">public class Foo() {
+<pre class="language-&quot;&gt;&lt;img/onerror=&quot;alert('hacked')&quot;src=.&gt;&lt;span\class=&quot;"><code class="language-&quot;&gt;&lt;img/onerror=&quot;alert('hacked')&quot;src=.&gt;&lt;span\class=&quot;">public class Foo() {
 	public Foo(bar) {
 		System.out.println(bar);
 	}

--- a/testdata/expected/fenced-with-html-in-language.html
+++ b/testdata/expected/fenced-with-html-in-language.html
@@ -1,0 +1,8 @@
+<h1>Test</h1>
+<p>This is a fenced code block:</p>
+<pre class="language-&lt;img/onerror=&quot;alert('hacked')&quot;src=.&gt;"><code class="language-&lt;img/onerror=&quot;alert('hacked')&quot;src=.&gt;">public class Foo() {
+	public Foo(bar) {
+		System.out.println(bar);
+	}
+}
+</code></pre>

--- a/testdata/input/fenced-with-html-in-language.md
+++ b/testdata/input/fenced-with-html-in-language.md
@@ -2,7 +2,7 @@
 
 This is a fenced code block:
 
-```<img/onerror="alert('hacked')"src=.>
+```"><img/onerror="alert('hacked')"src=.><span\class="
 public class Foo() {
 	public Foo(bar) {
 		System.out.println(bar);

--- a/testdata/input/fenced-with-html-in-language.md
+++ b/testdata/input/fenced-with-html-in-language.md
@@ -1,0 +1,11 @@
+# Test
+
+This is a fenced code block:
+
+```<img/onerror="alert('hacked')"src=.>
+public class Foo() {
+	public Foo(bar) {
+		System.out.println(bar);
+	}
+}
+```


### PR DESCRIPTION
Found a XSS vulnerability around filenames.

Here is a example to reproduce.

> \`\`\`"><img/onerror="alert(location)"src=.>
> aaa
> \`\`\`

I made a change so that filenames are escaped.
Thank you!