### PR TITLE
chore: prepare branch infrastructure for v5 development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, renovate/**]
+    branches: [main, v5, v4.x, renovate/**]
   pull_request: {}
 
 permissions:

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,5 +9,6 @@
          renovate/renovate --dry-run=full --platform=local
   */
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  baseBranches: ["main", "v5"],
   extends: ["github>jGleitz/renovate-config:default.json5"],
 }


### PR DESCRIPTION
Renovate baseBranches for v5 development; CI push triggers for v5 + v4.x so the integration branches run CI; no job renames.