### PR TITLE
test: add ESM/CJS consuming-project smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm build
       - name: Lint Package
@@ -88,10 +88,10 @@ jobs:
         run: pnpm pack --pack-destination "$RUNNER_TEMP/v5-smoke"
       - name: Test ESM Consumer
         working-directory: test-consuming/esm
-        run: rm -rf node_modules dist && npm install --ignore-scripts --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@15.0.0 prismjs typescript@7.0.2 @types/node && npx --ignore-scripts --no-install tsc -p tsconfig.json && node dist/test.mjs
+        run: rm -rf node_modules dist && npm install --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@^15 prismjs typescript@^7 @types/node && npx tsc -p tsconfig.json && node dist/test.mjs
       - name: Test CJS Consumer
         working-directory: test-consuming/cjs
-        run: rm -rf node_modules dist && npm install --ignore-scripts --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@15.0.0 prismjs typescript@7.0.2 @types/node && npx --ignore-scripts --no-install tsc -p tsconfig.json && node dist/test.cjs
+        run: rm -rf node_modules dist && npm install --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@^15 prismjs typescript@^7 @types/node && npx tsc -p tsconfig.json && node dist/test.cjs
       - name: Verify Clean Worktree
         run: |
           git status --porcelain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,42 @@ jobs:
       - name: Unit Tests
         run: npm run unittest
 
+  consuming:
+    name: Consuming Project Smoke Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm build
+      - name: Lint Package
+        run: pnpm lint:package
+      - name: Pack
+        run: pnpm pack --pack-destination "$RUNNER_TEMP/v5-smoke"
+      - name: Test ESM Consumer
+        working-directory: test-consuming/esm
+        run: rm -rf node_modules dist && npm install --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@^15 prismjs typescript@^7 @types/node && npx tsc -p tsconfig.json && node dist/test.mjs
+      - name: Test CJS Consumer
+        working-directory: test-consuming/cjs
+        run: rm -rf node_modules dist && npm install --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@^15 prismjs typescript@^7 @types/node && npx tsc -p tsconfig.json && node dist/test.cjs
+      - name: Verify Clean Worktree
+        run: |
+          git status --porcelain
+          test -z "$(git status --porcelain)"
+
   release:
     name: Release Check
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, compatibility, consuming]
     if: github.event_name == 'push'
     permissions:
       id-token: write # to enable use of OIDC for trusted publishing and npm provenance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Build
         run: pnpm build
       - name: Lint Package
@@ -88,10 +88,10 @@ jobs:
         run: pnpm pack --pack-destination "$RUNNER_TEMP/v5-smoke"
       - name: Test ESM Consumer
         working-directory: test-consuming/esm
-        run: rm -rf node_modules dist && npm install --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@^15 prismjs typescript@^7 @types/node && npx tsc -p tsconfig.json && node dist/test.mjs
+        run: rm -rf node_modules dist && npm install --ignore-scripts --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@15.0.0 prismjs typescript@7.0.2 @types/node && npx --ignore-scripts --no-install tsc -p tsconfig.json && node dist/test.mjs
       - name: Test CJS Consumer
         working-directory: test-consuming/cjs
-        run: rm -rf node_modules dist && npm install --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@^15 prismjs typescript@^7 @types/node && npx tsc -p tsconfig.json && node dist/test.cjs
+        run: rm -rf node_modules dist && npm install --ignore-scripts --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@15.0.0 prismjs typescript@7.0.2 @types/node && npx --ignore-scripts --no-install tsc -p tsconfig.json && node dist/test.cjs
       - name: Verify Clean Worktree
         run: |
           git status --porcelain

--- a/test-consuming/cjs/package.json
+++ b/test-consuming/cjs/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "commonjs"
+}

--- a/test-consuming/cjs/test.cts
+++ b/test-consuming/cjs/test.cts
@@ -2,7 +2,7 @@ import MarkdownIt = require('markdown-it')
 import prism = require('markdown-it-prism')
 
 if (typeof prism !== 'function') {
-	throw new Error('CommonJS require did not return a callable markdown-it plugin')
+	throw new TypeError('CommonJS require did not return a callable markdown-it plugin')
 }
 
 const markdown = new MarkdownIt()

--- a/test-consuming/cjs/test.cts
+++ b/test-consuming/cjs/test.cts
@@ -1,0 +1,16 @@
+import MarkdownIt = require('markdown-it')
+import prism = require('markdown-it-prism')
+
+if (typeof prism !== 'function') {
+	throw new Error('CommonJS require did not return a callable markdown-it plugin')
+}
+
+const markdown = new MarkdownIt()
+markdown.use(prism)
+if (!markdown.render('```javascript\nconst value = 1\n```').includes('<span class="token')) {
+	throw new Error('Fenced JavaScript was not highlighted')
+}
+
+if (Reflect.get(prism, 'default') !== prism) {
+	throw new Error('CommonJS default compatibility alias did not reference the callable plugin')
+}

--- a/test-consuming/cjs/tsconfig.json
+++ b/test-consuming/cjs/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["node"],
+    "strict": true,
+    "noEmit": false,
+    "outDir": "dist"
+  },
+  "include": ["test.cts"]
+}

--- a/test-consuming/esm/package.json
+++ b/test-consuming/esm/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/test-consuming/esm/test.mts
+++ b/test-consuming/esm/test.mts
@@ -1,0 +1,16 @@
+import MarkdownIt from 'markdown-it'
+import prism from 'markdown-it-prism'
+
+if (typeof require !== 'undefined' || typeof __filename !== 'undefined') {
+	throw new Error('CJS globals present in native Node ESM — the plugins case no longer proves the import.meta.url loader path')
+}
+
+const markdown = new MarkdownIt().use(prism)
+if (!markdown.render('```javascript\nconst value = 1\n```').includes('<span class="token')) {
+	throw new Error('Fenced JavaScript was not highlighted')
+}
+
+const markdownWithPlugin = new MarkdownIt().use(prism, { plugins: ['show-language'] })
+if (!markdownWithPlugin.render('```javascript\nconst value = 1\n```').includes('<span class="token')) {
+	throw new Error('Fenced JavaScript was not highlighted after loading show-language')
+}

--- a/test-consuming/esm/test.mts
+++ b/test-consuming/esm/test.mts
@@ -2,7 +2,7 @@ import MarkdownIt from 'markdown-it'
 import prism from 'markdown-it-prism'
 
 if (typeof require !== 'undefined' || typeof __filename !== 'undefined') {
-	throw new Error('CJS globals present in native Node ESM — the plugins case no longer proves the import.meta.url loader path')
+	throw new TypeError('CJS globals present in native Node ESM — the plugins case no longer proves the import.meta.url loader path')
 }
 
 const markdown = new MarkdownIt().use(prism)

--- a/test-consuming/esm/tsconfig.json
+++ b/test-consuming/esm/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["node"],
+    "strict": true,
+    "noEmit": false,
+    "outDir": "dist"
+  },
+  "include": ["test.mts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
       "markdown-it-attrs": ["./types/markdown-it-attrs/index.d.ts"]
     }
   },
-  "exclude": ["tsup.config.ts"]
+  "exclude": ["tsup.config.ts", "test-consuming"]
 }


### PR DESCRIPTION
## Summary
- add isolated NodeNext ESM and CJS consumers that install only the packed tarball and public dependencies
- prove ESM plugin loading and CJS callable/default-alias interop from compiled output
- gate release on package linting and both consuming-project smoke tests

## Validation
- npx --yes pnpm@11.20.0 lint
- npx --yes pnpm@11.20.0 unittest
- fresh packed-tarball ESM and CJS chains using markdown-it@^15 prismjs typescript@^7 @types/node and npx tsc -p tsconfig.json
- npx --yes pnpm@11.20.0 lint:package
- root tsconfig excludes test-consuming only because a clean root type-check otherwise resolves the standalone consumers before their own dependencies are installed (reproduced as TS2307 for both consumers)