### PR TITLE
feat: restore core bundler support for Webpack and Vite (plugins: remains Node-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         run: rm -rf node_modules dist && npm install --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@^15 prismjs webpack@5.109.2 jsdom@30.0.1 && node build.mjs && node run.mjs B
       - name: Test Vite Consumer
         working-directory: test-consuming/vite
-        run: rm -rf node_modules dist && npm install --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@^15 prismjs vite@8.2.0 jsdom@30.0.1 && npx vite build && node run.mjs B
+        run: rm -rf node_modules dist && npm install --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@^15 prismjs vite@8.2.0 jsdom@30.0.1 && npx --no-install vite build && node run.mjs B
       - name: Verify Clean Worktree
         run: |
           git status --porcelain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,12 @@ jobs:
       - name: Test CJS Consumer
         working-directory: test-consuming/cjs
         run: rm -rf node_modules dist && npm install --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@^15 prismjs typescript@^7 @types/node && npx tsc -p tsconfig.json && node dist/test.cjs
+      - name: Test Webpack Consumer
+        working-directory: test-consuming/webpack
+        run: rm -rf node_modules dist && npm install --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@^15 prismjs webpack@5.109.2 jsdom@30.0.1 && node build.mjs && node run.mjs B
+      - name: Test Vite Consumer
+        working-directory: test-consuming/vite
+        run: rm -rf node_modules dist && npm install --no-save --package-lock=false "$RUNNER_TEMP/v5-smoke/markdown-it-prism-0.0.0-development.tgz" markdown-it@^15 prismjs vite@8.2.0 jsdom@30.0.1 && npx vite build && node run.mjs B
       - name: Verify Clean Worktree
         run: |
           git status --porcelain

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 v5 is a major release with breaking changes. When upgrading from v4.x, check these points:
 
 1. **markdown-it v15 only.** v5 requires `markdown-it` v15. Older markdown-it versions (<15) are no longer supported.
-2. **Node.js 22 or later.** v5 requires Node.js >= 22.
+2. **Node.js 22.3 or later.** v5 requires Node.js >= 22.3.
 3. **Dual ESM and CJS.** v5 ships native ESM and CommonJS through conditional exports. `require('markdown-it-prism')` keeps working unchanged, and `import prism from 'markdown-it-prism'` is now a native ESM import.
 4. **Remove `@types/markdown-it`.** markdown-it bundles its own type definitions since v15, so you no longer need a separate `@types/markdown-it` dependency. Remove it if you have one.
-5. **Temporary regression: browser bundlers.** v5.0.0 does not work in browser bundlers (Webpack/Vite browser targets). Restoration is tracked in [#1147](https://github.com/jGleitz/markdown-it-prism/issues/1147). If you bundle this plugin for the browser, stay on v4.x until the restoration lands.
+5. **Browser bundlers support the core flow.** Webpack and Vite can bundle v5 when Prism languages are imported manually. The `plugins:` option remains Node.js-only in browser/bundler targets; completing plugin support is tracked in [#1147](https://github.com/jGleitz/markdown-it-prism/issues/1147).
 
 ## Usage
 
@@ -74,7 +74,7 @@ attribute.
 ## Usage with Webpack
 
 > [!IMPORTANT]
-> This section applies to markdown-it-prism **v4.x only**. v5.0.0 does not work in browser bundlers yet; restoration is tracked in [#1147](https://github.com/jGleitz/markdown-it-prism/issues/1147). Stay on v4.x for bundler usage until the restoration lands.
+> The `plugins:` option requires Node.js module loading and is not supported in browser/bundler targets. Import Prism languages manually as shown below. Browser plugin support is tracked in [#1147](https://github.com/jGleitz/markdown-it-prism/issues/1147).
 
 If you want to use this plugin together with [Webpack](https://webpack.js.org/), you need to import all languages you
 intend to use:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     }
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.3.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,15 @@ import type {
 	StateCore,
 	Token,
 } from 'markdown-it'
-const runtimeRequire = typeof require === 'function' && typeof process !== 'undefined'
-	? require
-	: typeof process !== 'undefined' && typeof process.getBuiltinModule === 'function'
-		? process.getBuiltinModule('node:module').createRequire(import.meta.url)
-		: undefined
+function resolveRuntimeRequire(): NodeJS.Require | undefined {
+	if (typeof require === 'function' && typeof process !== 'undefined') return require
+	if (typeof process !== 'undefined' && typeof process.getBuiltinModule === 'function') {
+		return process.getBuiltinModule('node:module').createRequire(import.meta.url)
+	}
+	return undefined
+}
+
+const runtimeRequire = resolveRuntimeRequire()
 
 const SPECIFIED_LANGUAGE_META_KEY = 'de.joshuagleitze.markdown-it-prism.specifiedLanguage'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,11 @@ import type {
 	StateCore,
 	Token,
 } from 'markdown-it'
-import { createRequire } from 'node:module'
-
-const require = createRequire(
-	typeof __filename === 'undefined' ? import.meta.url : __filename,
-)
+const runtimeRequire = typeof require === 'function' && typeof process !== 'undefined'
+	? require
+	: typeof process !== 'undefined' && typeof process.getBuiltinModule === 'function'
+		? process.getBuiltinModule('node:module').createRequire(import.meta.url)
+		: undefined
 
 const SPECIFIED_LANGUAGE_META_KEY = 'de.joshuagleitze.markdown-it-prism.specifiedLanguage'
 
@@ -87,8 +87,11 @@ function loadPrismGrammar(lang: string): Grammar | undefined {
  * @throws {Error} If there is no plugin with the provided `name`.
  */
 function loadPrismPlugin(name: string): void {
+	if (runtimeRequire === undefined) {
+		throw new Error('markdown-it-prism: the "plugins" option requires Node.js module loading and is not supported in browser/bundler targets — import Prism languages manually instead (tracking: https://github.com/jGleitz/markdown-it-prism/issues/1147)')
+	}
 	try {
-		require(`prismjs/plugins/${name}/prism-${name}`)
+		runtimeRequire(`prismjs/plugins/${name}/prism-${name}`)
 	} catch (cause) {
 		throw new Error(`Cannot load Prism plugin "${name}". Please check the spelling.`, { cause })
 	}

--- a/test-consuming/vite/index.html
+++ b/test-consuming/vite/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<body>
+	<div id="control"></div>
+	<div id="output"></div>
+	<div id="plugins"></div>
+	<div id="plugins-neg"></div>
+	<div id="plugins-dup"></div>
+	<script type="module" src="/src/main.js"></script>
+</body>

--- a/test-consuming/vite/package.json
+++ b/test-consuming/vite/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/test-consuming/vite/run.mjs
+++ b/test-consuming/vite/run.mjs
@@ -13,16 +13,15 @@ const script = dom.window.document.createElement('script')
 script.textContent = await readFile(new URL(`./dist/${entries[0].file}`, import.meta.url), 'utf8')
 dom.window.document.body.appendChild(script)
 
-const nodeOnlyError = 'markdown-it-prism: the "plugins" option requires Node.js module loading and is not supported in browser/bundler targets — import Prism languages manually instead (tracking: https://github.com/jGleitz/markdown-it-prism/issues/1147)'
-const unknownPluginError = 'Cannot load Prism plugin "definitely-not-a-prism-plugin". Please check the spelling.'
+const expectedPluginValue = mode === 'A' ? 'keyword-class' : 'markdown-it-prism: the "plugins" option requires Node.js module loading and is not supported in browser/bundler targets — import Prism languages manually instead (tracking: https://github.com/jGleitz/markdown-it-prism/issues/1147)'
+const expectedNegativeValue = mode === 'A' ? 'Cannot load Prism plugin "definitely-not-a-prism-plugin". Please check the spelling.' : expectedPluginValue
 const value = (id) => dom.window.document.querySelector(id)?.innerHTML ?? ''
-const results = {
-	CORE: value('#output').includes('<span class="token'),
-	PLUGINS: mode === 'A' ? value('#plugins').includes('keyword-class') : value('#plugins') === nodeOnlyError,
-	NEG: mode === 'A' ? value('#plugins-neg') === unknownPluginError : value('#plugins-neg') === nodeOnlyError,
-	CONTROL: value('#control').includes('class="token keyword"') && !value('#control').includes('keyword-class'),
-	DUP: mode === 'A' ? value('#plugins-dup').split('keyword-class').length - 1 === 1 : value('#plugins-dup') === nodeOnlyError,
-}
+const pluginMatches = (id) => mode === 'A' ? value(id).includes(expectedPluginValue) : value(id) === expectedPluginValue
+const results = Object.fromEntries([
+	['CORE', value('#output').includes('<span class="token')], ['PLUGINS', pluginMatches('#plugins')],
+	['NEG', value('#plugins-neg') === expectedNegativeValue], ['CONTROL', value('#control').includes('class="token keyword"') && !value('#control').includes('keyword-class')],
+	['DUP', mode === 'A' ? value('#plugins-dup').split('keyword-class').length - 1 === 1 : pluginMatches('#plugins-dup')],
+])
 
 for (const [name, passed] of Object.entries(results)) console.log(`${name}:${passed ? 'PASS' : 'FAIL'}`)
 if (Object.values(results).includes(false)) process.exitCode = 1

--- a/test-consuming/vite/run.mjs
+++ b/test-consuming/vite/run.mjs
@@ -22,6 +22,5 @@ const results = Object.fromEntries([
 	['NEG', value('#plugins-neg') === expectedNegativeValue], ['CONTROL', value('#control').includes('class="token keyword"') && !value('#control').includes('keyword-class')],
 	['DUP', mode === 'A' ? value('#plugins-dup').split('keyword-class').length - 1 === 1 : pluginMatches('#plugins-dup')],
 ])
-
 for (const [name, passed] of Object.entries(results)) console.log(`${name}:${passed ? 'PASS' : 'FAIL'}`)
 if (Object.values(results).includes(false)) process.exitCode = 1

--- a/test-consuming/vite/run.mjs
+++ b/test-consuming/vite/run.mjs
@@ -1,0 +1,28 @@
+import { readFile } from 'node:fs/promises'
+import { JSDOM } from 'jsdom'
+
+const mode = process.argv[2]
+if (mode !== 'A' && mode !== 'B') throw new Error('Expected mode A or B')
+
+const manifest = JSON.parse(await readFile(new URL('./dist/.vite/manifest.json', import.meta.url), 'utf8'))
+const entries = Object.values(manifest).filter((record) => record.isEntry === true)
+if (entries.length !== 1) throw new Error(`Expected exactly one manifest entry, received ${entries.length}`)
+
+const dom = new JSDOM('<!doctype html><body><div id="control"></div><div id="output"></div><div id="plugins"></div><div id="plugins-neg"></div><div id="plugins-dup"></div></body>', { runScripts: 'dangerously' })
+const script = dom.window.document.createElement('script')
+script.textContent = await readFile(new URL(`./dist/${entries[0].file}`, import.meta.url), 'utf8')
+dom.window.document.body.appendChild(script)
+
+const nodeOnlyError = 'markdown-it-prism: the "plugins" option requires Node.js module loading and is not supported in browser/bundler targets — import Prism languages manually instead (tracking: https://github.com/jGleitz/markdown-it-prism/issues/1147)'
+const unknownPluginError = 'Cannot load Prism plugin "definitely-not-a-prism-plugin". Please check the spelling.'
+const value = (id) => dom.window.document.querySelector(id)?.innerHTML ?? ''
+const results = {
+	CORE: value('#output').includes('<span class="token'),
+	PLUGINS: mode === 'A' ? value('#plugins').includes('keyword-class') : value('#plugins') === nodeOnlyError,
+	NEG: mode === 'A' ? value('#plugins-neg') === unknownPluginError : value('#plugins-neg') === nodeOnlyError,
+	CONTROL: value('#control').includes('class="token keyword"') && !value('#control').includes('keyword-class'),
+	DUP: mode === 'A' ? value('#plugins-dup').split('keyword-class').length - 1 === 1 : value('#plugins-dup') === nodeOnlyError,
+}
+
+for (const [name, passed] of Object.entries(results)) console.log(`${name}:${passed ? 'PASS' : 'FAIL'}`)
+if (Object.values(results).includes(false)) process.exitCode = 1

--- a/test-consuming/vite/src/main.js
+++ b/test-consuming/vite/src/main.js
@@ -1,0 +1,27 @@
+import MarkdownIt from 'markdown-it'
+import prism from 'markdown-it-prism'
+import 'prismjs/components/prism-clike.js'
+import 'prismjs/components/prism-java.js'
+
+const source = '```java\nclass Foo {}\n```'
+document.querySelector('#control').innerHTML = new MarkdownIt().use(prism).render(source)
+document.querySelector('#output').innerHTML = new MarkdownIt().use(prism).render(source)
+
+try {
+	document.querySelector('#plugins').innerHTML = new MarkdownIt().use(prism, { plugins: ['highlight-keywords'] }).render(source)
+} catch (error) {
+	document.querySelector('#plugins').textContent = error.message
+}
+
+try {
+	new MarkdownIt().use(prism, { plugins: ['definitely-not-a-prism-plugin'] })
+} catch (error) {
+	document.querySelector('#plugins-neg').textContent = error.message
+}
+
+try {
+	new MarkdownIt().use(prism, { plugins: ['highlight-keywords'] })
+	document.querySelector('#plugins-dup').innerHTML = new MarkdownIt().use(prism, { plugins: ['highlight-keywords'] }).render(source)
+} catch (error) {
+	document.querySelector('#plugins-dup').textContent = error.message
+}

--- a/test-consuming/vite/src/main.js
+++ b/test-consuming/vite/src/main.js
@@ -4,24 +4,12 @@ import 'prismjs/components/prism-clike.js'
 import 'prismjs/components/prism-java.js'
 
 const source = '```java\nclass Foo {}\n```'
-document.querySelector('#control').innerHTML = new MarkdownIt().use(prism).render(source)
-document.querySelector('#output').innerHTML = new MarkdownIt().use(prism).render(source)
-
-try {
-	document.querySelector('#plugins').innerHTML = new MarkdownIt().use(prism, { plugins: ['highlight-keywords'] }).render(source)
-} catch (error) {
-	document.querySelector('#plugins').textContent = error.message
+const render = (id, plugins = [], repeat = false) => {
+	try {
+		if (repeat) new MarkdownIt().use(prism, { plugins })
+		document.querySelector(id).innerHTML = new MarkdownIt().use(prism, { plugins }).render(source)
+	}
+	catch (error) { document.querySelector(id).textContent = error.message }
 }
-
-try {
-	new MarkdownIt().use(prism, { plugins: ['definitely-not-a-prism-plugin'] })
-} catch (error) {
-	document.querySelector('#plugins-neg').textContent = error.message
-}
-
-try {
-	new MarkdownIt().use(prism, { plugins: ['highlight-keywords'] })
-	document.querySelector('#plugins-dup').innerHTML = new MarkdownIt().use(prism, { plugins: ['highlight-keywords'] }).render(source)
-} catch (error) {
-	document.querySelector('#plugins-dup').textContent = error.message
-}
+render('#control'); render('#output'); render('#plugins', ['highlight-keywords'])
+render('#plugins-neg', ['definitely-not-a-prism-plugin']); render('#plugins-dup', ['highlight-keywords'], true)

--- a/test-consuming/vite/src/main.js
+++ b/test-consuming/vite/src/main.js
@@ -2,14 +2,12 @@ import MarkdownIt from 'markdown-it'
 import prism from 'markdown-it-prism'
 import 'prismjs/components/prism-clike.js'
 import 'prismjs/components/prism-java.js'
-
 const source = '```java\nclass Foo {}\n```'
 const render = (id, plugins = [], repeat = false) => {
 	try {
 		if (repeat) new MarkdownIt().use(prism, { plugins })
 		document.querySelector(id).innerHTML = new MarkdownIt().use(prism, { plugins }).render(source)
-	}
-	catch (error) { document.querySelector(id).textContent = error.message }
+	} catch (error) { document.querySelector(id).textContent = error.message }
 }
 render('#control'); render('#output'); render('#plugins', ['highlight-keywords'])
 render('#plugins-neg', ['definitely-not-a-prism-plugin']); render('#plugins-dup', ['highlight-keywords'], true)

--- a/test-consuming/vite/vite.config.js
+++ b/test-consuming/vite/vite.config.js
@@ -1,0 +1,11 @@
+export default {
+	build: {
+		manifest: true,
+		rollupOptions: {
+			output: {
+				format: 'iife',
+				inlineDynamicImports: true,
+			},
+		},
+	},
+}

--- a/test-consuming/webpack/build.mjs
+++ b/test-consuming/webpack/build.mjs
@@ -1,0 +1,15 @@
+import { fileURLToPath } from 'node:url'
+import webpack from 'webpack'
+
+webpack({
+	mode: 'production',
+	target: 'web',
+	entry: './src/main.js',
+	output: {
+		path: fileURLToPath(new URL('./dist', import.meta.url)),
+		filename: 'main.bundle.js',
+	},
+}, (error, stats) => {
+	if (error) throw error
+	if (stats?.hasErrors()) throw new Error(stats.toString({ all: false, errors: true }))
+})

--- a/test-consuming/webpack/package.json
+++ b/test-consuming/webpack/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/test-consuming/webpack/run.mjs
+++ b/test-consuming/webpack/run.mjs
@@ -1,0 +1,24 @@
+import { readFile } from 'node:fs/promises'
+import { JSDOM } from 'jsdom'
+
+const mode = process.argv[2]
+if (mode !== 'A' && mode !== 'B') throw new Error('Expected mode A or B')
+
+const dom = new JSDOM('<!doctype html><body><div id="control"></div><div id="output"></div><div id="plugins"></div><div id="plugins-neg"></div><div id="plugins-dup"></div></body>', { runScripts: 'dangerously' })
+const script = dom.window.document.createElement('script')
+script.textContent = await readFile(new URL('./dist/main.bundle.js', import.meta.url), 'utf8')
+dom.window.document.body.appendChild(script)
+
+const nodeOnlyError = 'markdown-it-prism: the "plugins" option requires Node.js module loading and is not supported in browser/bundler targets — import Prism languages manually instead (tracking: https://github.com/jGleitz/markdown-it-prism/issues/1147)'
+const unknownPluginError = 'Cannot load Prism plugin "definitely-not-a-prism-plugin". Please check the spelling.'
+const value = (id) => dom.window.document.querySelector(id)?.innerHTML ?? ''
+const results = {
+	CORE: value('#output').includes('<span class="token'),
+	PLUGINS: mode === 'A' ? value('#plugins').includes('keyword-class') : value('#plugins') === nodeOnlyError,
+	NEG: mode === 'A' ? value('#plugins-neg') === unknownPluginError : value('#plugins-neg') === nodeOnlyError,
+	CONTROL: value('#control').includes('class="token keyword"') && !value('#control').includes('keyword-class'),
+	DUP: mode === 'A' ? value('#plugins-dup').split('keyword-class').length - 1 === 1 : value('#plugins-dup') === nodeOnlyError,
+}
+
+for (const [name, passed] of Object.entries(results)) console.log(`${name}:${passed ? 'PASS' : 'FAIL'}`)
+if (Object.values(results).includes(false)) process.exitCode = 1

--- a/test-consuming/webpack/run.mjs
+++ b/test-consuming/webpack/run.mjs
@@ -9,16 +9,15 @@ const script = dom.window.document.createElement('script')
 script.textContent = await readFile(new URL('./dist/main.bundle.js', import.meta.url), 'utf8')
 dom.window.document.body.appendChild(script)
 
-const nodeOnlyError = 'markdown-it-prism: the "plugins" option requires Node.js module loading and is not supported in browser/bundler targets — import Prism languages manually instead (tracking: https://github.com/jGleitz/markdown-it-prism/issues/1147)'
-const unknownPluginError = 'Cannot load Prism plugin "definitely-not-a-prism-plugin". Please check the spelling.'
+const expectedPluginValue = mode === 'A' ? 'keyword-class' : 'markdown-it-prism: the "plugins" option requires Node.js module loading and is not supported in browser/bundler targets — import Prism languages manually instead (tracking: https://github.com/jGleitz/markdown-it-prism/issues/1147)'
+const expectedNegativeValue = mode === 'A' ? 'Cannot load Prism plugin "definitely-not-a-prism-plugin". Please check the spelling.' : expectedPluginValue
 const value = (id) => dom.window.document.querySelector(id)?.innerHTML ?? ''
-const results = {
-	CORE: value('#output').includes('<span class="token'),
-	PLUGINS: mode === 'A' ? value('#plugins').includes('keyword-class') : value('#plugins') === nodeOnlyError,
-	NEG: mode === 'A' ? value('#plugins-neg') === unknownPluginError : value('#plugins-neg') === nodeOnlyError,
-	CONTROL: value('#control').includes('class="token keyword"') && !value('#control').includes('keyword-class'),
-	DUP: mode === 'A' ? value('#plugins-dup').split('keyword-class').length - 1 === 1 : value('#plugins-dup') === nodeOnlyError,
-}
+const pluginMatches = (id) => mode === 'A' ? value(id).includes(expectedPluginValue) : value(id) === expectedPluginValue
+const results = Object.fromEntries([
+	['CORE', value('#output').includes('<span class="token')], ['PLUGINS', pluginMatches('#plugins')],
+	['NEG', value('#plugins-neg') === expectedNegativeValue], ['CONTROL', value('#control').includes('class="token keyword"') && !value('#control').includes('keyword-class')],
+	['DUP', mode === 'A' ? value('#plugins-dup').split('keyword-class').length - 1 === 1 : pluginMatches('#plugins-dup')],
+])
 
 for (const [name, passed] of Object.entries(results)) console.log(`${name}:${passed ? 'PASS' : 'FAIL'}`)
 if (Object.values(results).includes(false)) process.exitCode = 1

--- a/test-consuming/webpack/run.mjs
+++ b/test-consuming/webpack/run.mjs
@@ -9,14 +9,16 @@ const script = dom.window.document.createElement('script')
 script.textContent = await readFile(new URL('./dist/main.bundle.js', import.meta.url), 'utf8')
 dom.window.document.body.appendChild(script)
 
-const expectedPluginValue = mode === 'A' ? 'keyword-class' : 'markdown-it-prism: the "plugins" option requires Node.js module loading and is not supported in browser/bundler targets — import Prism languages manually instead (tracking: https://github.com/jGleitz/markdown-it-prism/issues/1147)'
-const expectedNegativeValue = mode === 'A' ? 'Cannot load Prism plugin "definitely-not-a-prism-plugin". Please check the spelling.' : expectedPluginValue
-const value = (id) => dom.window.document.querySelector(id)?.innerHTML ?? ''
-const pluginMatches = (id) => mode === 'A' ? value(id).includes(expectedPluginValue) : value(id) === expectedPluginValue
-const results = Object.fromEntries([
-	['CORE', value('#output').includes('<span class="token')], ['PLUGINS', pluginMatches('#plugins')],
-	['NEG', value('#plugins-neg') === expectedNegativeValue], ['CONTROL', value('#control').includes('class="token keyword"') && !value('#control').includes('keyword-class')],
-	['DUP', mode === 'A' ? value('#plugins-dup').split('keyword-class').length - 1 === 1 : pluginMatches('#plugins-dup')],
-])
-for (const [name, passed] of Object.entries(results)) console.log(`${name}:${passed ? 'PASS' : 'FAIL'}`)
-if (Object.values(results).includes(false)) process.exitCode = 1
+const html = Object.fromEntries(['control', 'output', 'plugins', 'plugins-neg', 'plugins-dup'].map((id) => [id, dom.window.document.querySelector(`#${id}`)?.innerHTML ?? '']))
+const nodeOnly = 'markdown-it-prism: the "plugins" option requires Node.js module loading and is not supported in browser/bundler targets — import Prism languages manually instead (tracking: https://github.com/jGleitz/markdown-it-prism/issues/1147)'
+const checks = mode === 'A' ? [
+	['CORE', html.output.includes('<span class="token')], ['PLUGINS', html.plugins.includes('keyword-class')],
+	['NEG', html['plugins-neg'] === 'Cannot load Prism plugin "definitely-not-a-prism-plugin". Please check the spelling.'],
+	['CONTROL', html.control.includes('class="token keyword"') && !html.control.includes('keyword-class')],
+	['DUP', html['plugins-dup'].split('keyword-class').length - 1 === 1],
+] : [
+	['CORE', html.output.includes('<span class="token')], ['PLUGINS', html.plugins === nodeOnly], ['NEG', html['plugins-neg'] === nodeOnly],
+	['CONTROL', html.control.includes('class="token keyword"') && !html.control.includes('keyword-class')], ['DUP', html['plugins-dup'] === nodeOnly],
+]
+for (const [name, passed] of checks) console.log(`${name}:${passed ? 'PASS' : 'FAIL'}`)
+if (checks.some(([, passed]) => !passed)) process.exitCode = 1

--- a/test-consuming/webpack/run.mjs
+++ b/test-consuming/webpack/run.mjs
@@ -18,6 +18,5 @@ const results = Object.fromEntries([
 	['NEG', value('#plugins-neg') === expectedNegativeValue], ['CONTROL', value('#control').includes('class="token keyword"') && !value('#control').includes('keyword-class')],
 	['DUP', mode === 'A' ? value('#plugins-dup').split('keyword-class').length - 1 === 1 : pluginMatches('#plugins-dup')],
 ])
-
 for (const [name, passed] of Object.entries(results)) console.log(`${name}:${passed ? 'PASS' : 'FAIL'}`)
 if (Object.values(results).includes(false)) process.exitCode = 1

--- a/test-consuming/webpack/src/main.js
+++ b/test-consuming/webpack/src/main.js
@@ -1,0 +1,27 @@
+import MarkdownIt from 'markdown-it'
+import prism from 'markdown-it-prism'
+import 'prismjs/components/prism-clike.js'
+import 'prismjs/components/prism-java.js'
+
+const source = '```java\nclass Foo {}\n```'
+document.querySelector('#control').innerHTML = new MarkdownIt().use(prism).render(source)
+document.querySelector('#output').innerHTML = new MarkdownIt().use(prism).render(source)
+
+try {
+	document.querySelector('#plugins').innerHTML = new MarkdownIt().use(prism, { plugins: ['highlight-keywords'] }).render(source)
+} catch (error) {
+	document.querySelector('#plugins').textContent = error.message
+}
+
+try {
+	new MarkdownIt().use(prism, { plugins: ['definitely-not-a-prism-plugin'] })
+} catch (error) {
+	document.querySelector('#plugins-neg').textContent = error.message
+}
+
+try {
+	new MarkdownIt().use(prism, { plugins: ['highlight-keywords'] })
+	document.querySelector('#plugins-dup').innerHTML = new MarkdownIt().use(prism, { plugins: ['highlight-keywords'] }).render(source)
+} catch (error) {
+	document.querySelector('#plugins-dup').textContent = error.message
+}

--- a/test-consuming/webpack/src/main.js
+++ b/test-consuming/webpack/src/main.js
@@ -4,24 +4,12 @@ import 'prismjs/components/prism-clike.js'
 import 'prismjs/components/prism-java.js'
 
 const source = '```java\nclass Foo {}\n```'
-document.querySelector('#control').innerHTML = new MarkdownIt().use(prism).render(source)
-document.querySelector('#output').innerHTML = new MarkdownIt().use(prism).render(source)
-
-try {
-	document.querySelector('#plugins').innerHTML = new MarkdownIt().use(prism, { plugins: ['highlight-keywords'] }).render(source)
-} catch (error) {
-	document.querySelector('#plugins').textContent = error.message
+const render = (id, plugins = [], repeat = false) => {
+	try {
+		if (repeat) new MarkdownIt().use(prism, { plugins })
+		document.querySelector(id).innerHTML = new MarkdownIt().use(prism, { plugins }).render(source)
+	}
+	catch (error) { document.querySelector(id).textContent = error.message }
 }
-
-try {
-	new MarkdownIt().use(prism, { plugins: ['definitely-not-a-prism-plugin'] })
-} catch (error) {
-	document.querySelector('#plugins-neg').textContent = error.message
-}
-
-try {
-	new MarkdownIt().use(prism, { plugins: ['highlight-keywords'] })
-	document.querySelector('#plugins-dup').innerHTML = new MarkdownIt().use(prism, { plugins: ['highlight-keywords'] }).render(source)
-} catch (error) {
-	document.querySelector('#plugins-dup').textContent = error.message
-}
+render('#control'); render('#output'); render('#plugins', ['highlight-keywords'])
+render('#plugins-neg', ['definitely-not-a-prism-plugin']); render('#plugins-dup', ['highlight-keywords'], true)

--- a/test-consuming/webpack/src/main.js
+++ b/test-consuming/webpack/src/main.js
@@ -2,14 +2,12 @@ import MarkdownIt from 'markdown-it'
 import prism from 'markdown-it-prism'
 import 'prismjs/components/prism-clike.js'
 import 'prismjs/components/prism-java.js'
-
 const source = '```java\nclass Foo {}\n```'
 const render = (id, plugins = [], repeat = false) => {
 	try {
 		if (repeat) new MarkdownIt().use(prism, { plugins })
 		document.querySelector(id).innerHTML = new MarkdownIt().use(prism, { plugins }).render(source)
-	}
-	catch (error) { document.querySelector(id).textContent = error.message }
+	} catch (error) { document.querySelector(id).textContent = error.message }
 }
 render('#control'); render('#output'); render('#plugins', ['highlight-keywords'])
 render('#plugins-neg', ['definitely-not-a-prism-plugin']); render('#plugins-dup', ['highlight-keywords'], true)


### PR DESCRIPTION
## Summary

- replace the static `node:module` import with the guarded Node CJS / Node >=22.3 ESM loader
- restore core browser-bundler highlighting in real packed Webpack 5.109.2 and Vite 8.2.0 consumers
- keep `plugins:` explicit and Node-only in browser targets, with the exact issue-linked runtime error
- document the restored core flow and remaining plugin gap

## Deterministic research result

Outcome **B** was selected by the T19 algorithm. The untouched v5 baseline failed CORE on the static `node:module` dependency. Candidate 1 passed both mode-B bundler harnesses, packed Node ESM/CJS consumers, and all 45 tests. Candidate 2 passed Vite mode A and its registry test but failed Webpack because its generated plugin context eagerly executed unrequested Prism plugins; all candidate-2 traces were removed.

## Verification

- `pnpm lint`
- `pnpm unittest` (45/45)
- `pnpm build` (exactly four artifacts; CJS default footer present)
- `pnpm lint:package` (publint + attw)
- TypeScript native 7.0.2 and tooling 6.0.3
- markdown-it 15 compatibility: frozen install, type-check, tests
- fresh packed ESM and CJS consumers
- fresh packed Webpack and Vite consumers via `node run.mjs B` (all CORE/PLUGINS/NEG/CONTROL/DUP assertions pass)

## Tracking

Issue #1147 is re-scoped to selective `plugins:` support in browser bundlers and remains open for v5.x.